### PR TITLE
Add post on RSS experiment

### DIFF
--- a/content/articles/blog/experiment.md
+++ b/content/articles/blog/experiment.md
@@ -1,0 +1,45 @@
+Title: An experiment
+Date: 2022-05-06
+Slug: experiment
+Summary: I am launching a small experiment. Would you like to help?
+
+A little while back, I posted on my Twitter and Mastodon feeds[^crossposter]
+asking people who kept a personal blog to post their RSS or Atom feed
+URLs. A surprising number of people responded — many more on Mastodon
+than on Twitter, incidentally, though I have about 15 times as many
+Twitter as Mastodon followers. You can find the Twitter thread
+[here](https://twitter.com/xahteiwi/status/1515233714162356224) and the
+Mastodon thread
+[here](https://mastodon.social/@xahteiwi/108140619829880299).
+
+[^crossposter]: If you’re curious about these things: I use [Renato
+  Cerqueira](https://lond.com.br/)’s [Mastodon Twitter
+  Crossposter](https://crossposter.masto.donte.com.br/) to mirror my
+  Twitter feed to Mastodon, and vice versa. You can take a look at its
+  [GitHub
+  project](https://github.com/renatolond/mastodon-twitter-poster).
+
+I now have a very decent aggregated feed, thanks to all who responded!
+
+Now, normally, when I put a new post out, I chuck out a link to the
+post on those two social networks. For some time, I’d like to do
+something different, and if you’re inclined, you can help!
+
+So what I’d ask you to do is subscribe to the [RSS
+feed](/feeds/all.rss.xml) or the [Atom feed](/feeds/all.atom.xml) for my
+site. For the next few things I post, I will **not** link them on
+Twitter or Mastodon — but if you notice them in your feed and find them
+share-worthy, I would very much appreciate if *you* posted them there.[^analytics]
+Feel free to tag me in them, I’m `@xahteiwi` on Twitter and
+`@xahteiwi@mastodon.social` on Mastodon.
+
+[^analytics]: I don’t want to run Google Analytics on this site out of
+  concern for your privacy, which is why I don't know where my traffic
+  comes from. If you post them and tag me, I have something
+  functionally approaching a pingback beacon.
+
+I’d be really curious to see if it’s feasible in 2022 to reach blog
+readers with essentially just an RSS feed, and word-of-mouth.
+
+So, if you would like to participate, then just add my feed to your
+reader, and keep your eyes peeled for the next few articles. Thank you!


### PR DESCRIPTION
Add a post explaining that new articles won't go on Twitter or Mastodon for a while, but instead will only go out via the RSS feed.