### PR TITLE
Fix link in post Entropy to post Flat Org Scaling

### DIFF
--- a/content/articles/blog/entropy.md
+++ b/content/articles/blog/entropy.md
@@ -133,7 +133,7 @@ your organization’s entropy decelerator.
 
 * Somebody wants to “open up team communications”, or “flatten the
   organization”, so that everyone’s [complete
-  graph](%7Bfilename%7Dflat-org-scaling.md) has way more edges?
+  graph]({filename}flat-org-scaling.md) has way more edges?
   That’s when you educate them about ${n(n-1)}\over 2$, and what
   quadratic growth means.
 


### PR DESCRIPTION
Curly braces got escaped to `%7B` and `%7D` which breaks the link
generation.

This commit should fix the link to get generated properly.

PS: I admit to not building and testing locally because the submodule count
is over 40 – my apologies.